### PR TITLE
DPCY not fulfilled & Slack notifications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       SDK_CONFIG: ${SDK_CONFIG}
       SEED_PHRASE: ${SEED_PHRASE}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      SERVER_IP: ${PROMETHEUS_SERVER_IP}
     restart: always
 
   # Prometheus with alertmanager

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@d8x/perpetuals-sdk": "1.1.28",
     "@pythnetwork/pyth-sdk-solidity": "^2.2.1",
+    "@slack/webhook": "^7.0.2",
     "@types/ws": "^8.5.5",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.2",

--- a/sample.env
+++ b/sample.env
@@ -11,3 +11,6 @@ REDIS_PASSWORD="thisismypassword"
 ### Deployment name and server ip address used in prometheus alerts
 PROMETHEUS_DEPLOYMENT_NAME="testing-executor-deployment"
 PROMETHEUS_SERVER_IP="127.0.0.1"
+
+### Slack webhook for posting execution revert messages
+SLACK_WEBHOOK_URL=""

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -748,7 +748,7 @@ export default class Distributor {
     // can be a case when a reduce-only order is dependent on another parent
     // order. If this check would be done after reduce only check, in case
     // traderPos === 0 order would still be sent off for execution which would
-    // cause dcpy not fulfilled error.
+    // cause dpcy not fulfilled error.
     if (order.order.parentChildOrderIds) {
       if (
         order.order.parentChildOrderIds[0] == ZERO_ORDER_ID &&

--- a/src/executor/reverts.ts
+++ b/src/executor/reverts.ts
@@ -1,0 +1,105 @@
+import { TransactionResponse, Provider } from "@ethersproject/providers";
+import { IncomingWebhook } from "@slack/webhook";
+import { utils } from "ethers";
+
+// sendTxRevertedMessage sends a message to the Slack channel when a transaction
+// is reverted with reason other than execution frontruns
+export const sendTxRevertedMessage = async (
+  revertReason: Promise<string>,
+  txHash: string,
+  orderDigest: string,
+  perpetualSymbol: string
+) => {
+  const revertMsg = await revertReason;
+
+  // Skip reverts which should be ignored
+  const whiteList = ["order not found"];
+  for (const msg of whiteList) {
+    if (revertMsg.toLowerCase().includes(msg.toLowerCase())) {
+      return;
+    }
+  }
+  console.log("transaction reverted with non-whitelisted reason", {
+    revertReasonMessage: revertMsg,
+    txHash,
+    orderDigest,
+  });
+
+  // Send message to Slack
+  const endpoint = process.env.SLACK_WEBHOOK_URL!;
+  if (endpoint === undefined || endpoint === "") {
+    console.log("SLACK_WEBHOOK_URL not set, skipping Slack notification");
+    return;
+  }
+
+  const webhook = new IncomingWebhook(endpoint);
+  await webhook.send({
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "🚨 executing order failed",
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `Revert reason: *${revertMsg}*`,
+        },
+      },
+      {
+        type: "divider",
+      },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Network*\n${process.env.SDK_CONFIG}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Server IP*\n${process.env.SERVER_IP}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Order digest*\n${orderDigest}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Symbol*\n${perpetualSymbol}`,
+          },
+        ],
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Tx hash*\n${txHash}`,
+        },
+      },
+    ],
+  });
+};
+
+// getTxRevertReason retrieves revert reason string
+export const getTxRevertReason = async (
+  tx: TransactionResponse,
+  p: Provider
+) => {
+  const txResp = await p.call(
+    {
+      to: tx.to,
+      from: tx.from,
+      data: tx.data,
+      value: tx.value,
+    },
+    tx.blockNumber
+  );
+
+  // Substring 128 also works. revert => Error(string)
+  return utils.toUtf8String("0x" + txResp.substring(138)).trim();
+};

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -4,7 +4,7 @@ import {
   LimitOrderBook,
   MarketData,
   PerpetualDataHandler,
-  ZERO_ADDRESS,
+  ZERO_ORDER_ID,
 } from "@d8x/perpetuals-sdk";
 import { BigNumber } from "@ethersproject/bignumber";
 import {
@@ -468,7 +468,7 @@ export default class BlockhainListener {
             const orderDependency = await ob.orderDependency(digest);
             if (orderDependency) {
               const [id1, id2] = [orderDependency[0], orderDependency[1]];
-              if (id1 !== ZERO_ADDRESS && id2 !== ZERO_ADDRESS) {
+              if (id1 !== ZERO_ORDER_ID || id2 !== ZERO_ORDER_ID) {
                 msg.order.parentChildOrderIds = [id1, id2];
               }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,6 +405,20 @@
   resolved "https://registry.yarnpkg.com/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.1.tgz#604e71840b68d688281a64369e377dfc7109173e"
   integrity sha512-Tb/5fWrQBRZ+IHDQVz3GiHh6+ZbgeS/muaNosJrD94cuL6DuAwcr7yEgMq4DrlPSrb+x7Vw8d5NMOvpsC7+Vlw==
 
+"@slack/types@^2.9.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.11.0.tgz#948c556081c3db977dfa8433490cc2ff41f47203"
+  integrity sha512-UlIrDWvuLaDly3QZhCPnwUSI/KYmV1N9LyhuH6EDKCRS1HWZhyTG3Ja46T3D0rYfqdltKYFXbJSSRPwZpwO0cQ==
+
+"@slack/webhook@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@slack/webhook/-/webhook-7.0.2.tgz#e69d4c8116584fab90e40a1076233de95b737d07"
+  integrity sha512-dsrO/ow6a6+xkLm/lZKbUNTsFJlBc679tD+qwlVTztsQkDxPLH6odM7FKALz1IHa+KpLX8HKUIPV13a7y7z29w==
+  dependencies:
+    "@slack/types" "^2.9.0"
+    "@types/node" ">=18.0.0"
+    axios "^1.6.3"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -482,6 +496,13 @@
   version "20.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.0.tgz#9d7daa855d33d4efec8aea88cd66db1c2f0ebe16"
   integrity sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==
+
+"@types/node@>=18.0.0":
+  version "20.14.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.1.tgz#2434dbcb1f039e31f2c0e9969da93f52cf6348f3"
+  integrity sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^18.15.3":
   version "18.17.15"
@@ -589,10 +610,24 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+axios@^1.6.3:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -737,6 +772,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 command-line-args@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
@@ -825,6 +867,11 @@ define-data-property@^1.1.4:
     es-define-property "^1.0.0"
     es-errors "^1.3.0"
     gopd "^1.0.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 denque@^2.1.0:
   version "2.1.0"
@@ -1007,6 +1054,20 @@ find-yarn-workspace-root@^2.0.0:
   integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
   dependencies:
     micromatch "^4.0.2"
+
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -1316,7 +1377,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -1494,6 +1555,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 qs@6.11.0:
   version "6.11.0"
@@ -1797,6 +1863,11 @@ typical@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
This PR introduces a bugfix for missing order dependency information when `PerpetualLimitOrderCreated` event is received and prevents child order execution submission before parent order is executed. Also introduces slack notifications for failed transactions.

How it was previously: parent child order ids are available when orders are
queried via `refreshOpenOrders`. This happens on `commander/distributor`
startup or at defined interval (10s atm) or based on config setting. When
order created event `PerpetualLimitOrderCreated` is received on `sentinel`
svc, `parentChildOrderIds` property is not set as this information is not
defined in the event data. Since SDK's
`perpetualDataHandler.fromSmartContractOrder` simply takes available values
from provided smartcontract order (payload from event in this case),
`parentChildOrderIds` would always be set to undefined for new orders.
Because of this, `isExecutableIfOnChain` would skip order dependency checks
for freshly received orders. 

Additionally, reduce only order check was taking precedence over order
dependency checks. Because of this, in certain situations it would make child
order to be sent for execution before parent was executed. This would end up
in dependency fulfillment failures like the following txs:
https://www.oklink.com/xlayer/tx/0x236603f391c66353f42f15578ecbcf80b32fe96be2ab500fd94740e4054aa050
or
https://www.okx.com/web3/explorer/xlayer-test/tx/0x961e09c261cb70b8b5a42de3cf83041bca6d034b85daec9ba1ea2b614258c6c2

