### PR TITLE
add recent parent order execution checks

### DIFF
--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -22,8 +22,8 @@ import { ExecutorMetrics } from "./metrics";
 import { getTxRevertReason, sendTxRevertedMessage } from "./reverts";
 import Distributor from "./distributor";
 
-// How much back in time we consider order to be recent. Currently 5 minutes.
-const RECENT_ORDER_TIME_S = 5 * 60;
+// How much back in time we consider order to be recent. Currently 2 minutes.
+const RECENT_ORDER_TIME_S = 2 * 60;
 
 export default class Executor {
   // objects
@@ -230,11 +230,10 @@ export default class Executor {
     });
   }
 
-  // For a recent (less than 5 minutes from submission ts as defined in
-  // RECENT_ORDER_TIME_S) child order, checks if parent order was executed
-  // recently. Provided childOrder must be a child order - no additional checks
-  // for that are made. If order is not so recent, all checks are simply
-  // ignored.
+  // For a recent (less than RECENT_ORDER_TIME_S from submission ts) child
+  // order, checks if parent order was executed recently. Provided childOrder
+  // must be a child order - no additional checks for that are made. If order is
+  // not so recent, all checks are simply ignored.
   public wasParentExecutedRecentlyForRecentChild(childOrder: Order): boolean {
     if (
       childOrder.submittedTimestamp! + RECENT_ORDER_TIME_S >


### PR DESCRIPTION
This PR introduces a parent order execution check for recent child orders.

There can be a situation when RPC sends child order created event before parent order. This might cause child order to be sent for execution before parent order's execution transaction is submitted. This PR adds parent order execution tracking for orders which were submitted in the last 2 minutes. Older orders are not checked for this constraint, since all parent order information should already be there for older orders. Recent child orders are allowed to be executed only once current executor instance submits the parent order execution transaction.
