### PR TITLE
Delay

### DIFF
--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -1,8 +1,11 @@
 import {
   ABK64x64ToFloat,
   BUY_SIDE,
+  containsFlag,
   IdxPriceInfo,
   MarketData,
+  MASK_CLOSE_ONLY,
+  MASK_KEEP_POS_LEVERAGE,
   Multicall3,
   Multicall3__factory,
   MULTICALL_ADDRESS,
@@ -12,6 +15,7 @@ import {
   ORDER_TYPE_STOP_LIMIT,
   ORDER_TYPE_STOP_MARKET,
   PerpetualDataHandler,
+  priceToProb,
   SELL_SIDE,
   ZERO_ORDER_ID,
 } from "@d8-x/d8x-node-sdk";
@@ -345,24 +349,18 @@ export default class Distributor {
           }
 
           case "BrokerOrderCreatedEvent": {
-            const {
-              chainId,
-              symbol,
-              traderAddr,
-              digest,
-              type,
-            }: BrokerOrderMsg = JSON.parse(msg);
-            if (chainId !== this.chainId) {
+            const m: BrokerOrderMsg = JSON.parse(msg);
+            if (m.chainId !== this.chainId) {
               break;
             }
-            this.brokerHandled.add(digest);
-            this.orderSource.set(digest, "broker");
-            this.addOrder(symbol, traderAddr, digest, type, undefined);
-            if (!this.eligibleAfterTs.has(digest)) {
+            this.brokerHandled.add(m.digest);
+            this.orderSource.set(m.digest, "broker");
+            this.addOrder(m.symbol, m.traderAddr, m.digest, m.type, this.brokerMsgToOrder(m));
+            if (!this.eligibleAfterTs.has(m.digest)) {
               const delayMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
-              this.eligibleAfterTs.set(digest, Date.now() + delayMs);
+              this.eligibleAfterTs.set(m.digest, Date.now() + delayMs);
             }
-            this.scheduleBrokerExecution(symbol, digest);
+            this.scheduleBrokerExecution(m.symbol, m.digest);
             break;
           }
 
@@ -520,6 +518,28 @@ export default class Distributor {
       }
     }
     this.tradePremium.set(symbol, prem);
+  }
+
+  private brokerMsgToOrder(m: BrokerOrderMsg): Order {
+    const flags = BigInt(m.flags);
+    const fAmount = BigInt(m.fAmount);
+    const fLimit = BigInt(m.fLimitPrice);
+    const fStop = BigInt(m.fTriggerPrice);
+    const isPM = this.md.isPredictionMarket(m.symbol);
+    const limit = fLimit === 0n ? undefined : ABK64x64ToFloat(fLimit);
+    const stop = fStop === 0n ? undefined : ABK64x64ToFloat(fStop);
+    return {
+      symbol: m.symbol,
+      side: fAmount >= 0n ? BUY_SIDE : SELL_SIDE,
+      type: m.type,
+      quantity: Math.abs(ABK64x64ToFloat(fAmount)),
+      reduceOnly: containsFlag(flags, MASK_CLOSE_ONLY),
+      limitPrice: isPM && limit !== undefined ? priceToProb(limit) : limit,
+      keepPositionLvg: containsFlag(flags, MASK_KEEP_POS_LEVERAGE),
+      stopPrice: isPM && stop !== undefined ? priceToProb(stop) : stop,
+      deadline: m.iDeadline,
+      executionTimestamp: m.executionTimestamp,
+    };
   }
 
   private addOrder(

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -785,7 +785,7 @@ export default class Distributor {
         continue;
       }
 
-      await this.waitUntilDelayElapsed(orderBundle);
+      await this.waitUntilDelayElapsed();
       if (!this.openOrders.get(symbol)?.has(digest)) continue;
 
       try {
@@ -807,7 +807,7 @@ export default class Distributor {
     return;
   }
 
-  private async waitUntilDelayElapsed(_orderBundle: OrderBundle) {
+  private async waitUntilDelayElapsed() {
     const delay = this.config.orderDelaySec ?? 0;
     if (delay <= 0) return;
     await sleep(delay * 1_000);

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -76,6 +76,8 @@ export default class Distributor {
   private brokerHandled: Set<string> = new Set();
   // Earliest wall clock ms at which a digest may be sent for execution
   private eligibleAfterTs: Map<string, number> = new Map();
+  // Which path learned about each digest first
+  private orderSource: Map<string, "broker" | "sentinel" | "refresh"> = new Map();
 
   constructor(config: ExecutorConfig, private executor: Executor) {
     this.config = config;
@@ -128,20 +130,30 @@ export default class Distributor {
     }
 
     const info = await this.md.exchangeInfo();
-    logger.info(JSON.stringify(info, undefined, "  "));
+    const runningPools = info.pools.filter((p) => p.isRunning);
+    const allPerps = runningPools.flatMap((p) => p.perpetuals);
+    logger.info({
+      info: "exchange info",
+      proxyAddr: info.proxyAddr,
+      chainId: Number(this.md.chainId),
+      runningPools: runningPools.length,
+      totalPerps: allPerps.length,
+      normalPerps: allPerps.filter((p) => p.state === "NORMAL").length,
+      poolSymbols: runningPools.map((p) => p.poolSymbol),
+    });
+    logger.debug({ info: "full exchange info", exchange: info });
 
-    const symbols = info.pools
-      .filter(({ isRunning }) => isRunning)
-      .map((pool) =>
+    const symbols = runningPools
+      .flatMap((pool) =>
         pool.perpetuals
           .filter(({ state }) => state === "NORMAL")
           .map(
             (perpetual) =>
               `${perpetual.baseCurrency}-${perpetual.quoteCurrency}-${pool.poolSymbol}`
           )
-      )
-      .flat();
-    logger.info({ symbols });
+      );
+    logger.info({ info: "tracked symbols", count: symbols.length });
+    logger.debug({ info: "tracked symbols", symbols });
 
     for (const symbol of symbols) {
       try {
@@ -314,8 +326,10 @@ export default class Distributor {
               order
             );
             await this.updatePriceCurve(symbol);
-            if (!this.openPositions.get(symbol)?.has(trader)) {
-              // new trader, refresh
+            if (
+              order.reduceOnly &&
+              !this.openPositions.get(symbol)?.has(trader)
+            ) {
               await this.refreshAccount(symbol, trader);
             }
             if (!this.brokerHandled.has(digest)) {
@@ -325,6 +339,7 @@ export default class Distributor {
               // and will be picked up by the block handler when it is
               const delayMs = (this.config.orderDelaySec ?? 0) * 1_000;
               this.eligibleAfterTs.set(digest, Date.now() + delayMs);
+              if (!this.orderSource.has(digest)) this.orderSource.set(digest, "sentinel");
             }
             break;
           }
@@ -341,6 +356,7 @@ export default class Distributor {
               break;
             }
             this.brokerHandled.add(digest);
+            this.orderSource.set(digest, "broker");
             this.addOrder(symbol, traderAddr, digest, type, undefined);
             const delayMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
             this.eligibleAfterTs.set(digest, Date.now() + delayMs);
@@ -378,16 +394,22 @@ export default class Distributor {
           }
 
           case "ExecutionFailedEvent": {
-            const {
-              chainId,
+            const parsed: ExecutionFailedMsg = JSON.parse(msg);
+            const { chainId, symbol, digest, trader, reason, hash, block } =
+              parsed;
+            if (chainId !== this.chainId) {
+              break;
+            }
+            logger.warn({
+              info: "ExecutionFailedEvent",
               symbol,
               digest,
               trader,
               reason,
-            }: ExecutionFailedMsg = JSON.parse(msg);
-            if (chainId !== this.chainId) {
-              break;
-            }
+              source: this.orderSource.get(digest) ?? "unknown",
+              txHash: hash,
+              block,
+            });
             if (reason != "cancel delay required") {
               this.removeOrder(symbol, digest, reason, trader);
             }
@@ -452,6 +474,17 @@ export default class Distributor {
    * @param symbol
    */
   private async updatePriceCurve(symbol: string) {
+    const orders = this.openOrders.get(symbol);
+    if (orders) {
+      let hasPriceGated = false;
+      for (const { order } of orders.values()) {
+        if (order && order.type !== ORDER_TYPE_MARKET) {
+          hasPriceGated = true;
+          break;
+        }
+      }
+      if (!hasPriceGated) return;
+    }
     const blockLatency = 2;
     if (
       this.priceCurveUpdatedAtBlock.has(symbol) &&
@@ -531,6 +564,8 @@ export default class Distributor {
     this.openOrders.get(symbol)?.delete(digest);
     this.brokerHandled.delete(digest);
     this.eligibleAfterTs.delete(digest);
+    // keep orderSource around briefly so late ExecutionFailed logs can still show path
+    setTimeout(() => this.orderSource.delete(digest), 30_000);
     logger.debug({
       info: "order removed",
       reason: reason,
@@ -606,10 +641,10 @@ export default class Distributor {
       const chunkSize = 500;
       let start = 0;
       while (true) {
-        const [orders, digests] = (await executeWithTimeout(
+        const [orders, digests, submittedTs] = (await executeWithTimeout(
           ob.pollRange(start, chunkSize),
           this.RPC_TIMEOUT_MS
-        )) as [any[], string[], unknown];
+        )) as [any[], string[], bigint[]];
         let found = 0;
         for (let j = 0; j < orders.length; j++) {
           const digest = digests[j];
@@ -620,6 +655,7 @@ export default class Distributor {
             co.parentChildDigest1,
             co.parentChildDigest2,
           ];
+          order.submittedTimestamp = Number(submittedTs[j]);
           orderBundles.set(digest, {
             symbol,
             trader: co.traderAddr,
@@ -628,6 +664,7 @@ export default class Distributor {
             order,
             type: order.type as OrderType,
           });
+          if (!this.orderSource.has(digest)) this.orderSource.set(digest, "refresh");
           found++;
         }
         if (found < chunkSize) break;
@@ -851,8 +888,17 @@ export default class Distributor {
     const waitMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
     await sleep(waitMs);
     for (let i = 0; i < 4; i++) {
-      if (await this.tryExecute(symbol, digest)) return;
+      if (this.messageSentAt.has(digest)) {
+        logger.debug({
+          info: "broker path skipped: already handled by main path",
+          symbol,
+          digest,
+        });
+        this.brokerHandled.delete(digest);
+        return;
+      }
       if (!this.openOrders.get(symbol)?.has(digest)) return;
+      if (await this.tryExecute(symbol, digest)) return;
       await sleep(1_000);
     }
   }

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -24,6 +24,7 @@ import { JsonRpcProvider } from "ethers";
 import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import {
+  BrokerOrderMsg,
   ExecuteOrderCommand,
   ExecutionFailedMsg,
   ExecutorConfig,
@@ -70,6 +71,13 @@ export default class Distributor {
 
   // Last time when refreshAllOpenOrders was called
   private lastRefreshOfAllOpenOrders: Date = new Date();
+
+  private readonly RPC_TIMEOUT_MS = 10_000;
+
+  // Digests whose broker WS handler has taken ownership of execution
+  private brokerHandled: Set<string> = new Set();
+  // Earliest wall clock ms at which a digest may be sent for execution
+  private eligibleAfterTs: Map<string, number> = new Map();
 
   constructor(config: ExecutorConfig, private executor: Executor) {
     this.config = config;
@@ -186,6 +194,7 @@ export default class Distributor {
       "ExecutionFailedEvent",
       "PerpetualLimitOrderCreatedEvent",
       "PerpetualLimitOrderCancelledEvent",
+      "BrokerOrderCreatedEvent",
       "Restart",
       "switch-mode",
       "listener-error",
@@ -311,7 +320,33 @@ export default class Distributor {
               // new trader, refresh
               await this.refreshAccount(symbol, trader);
             }
-            await this.checkOrders(symbol);
+            if (!this.brokerHandled.has(digest)) {
+              // the order is not yet handled by broker WS path
+              // in this path only wait for the delay and try execute, without retries, 
+              // because if sentinel has not fired yet, it means the order is not yet in the open orders map, 
+              // and will be picked up by the block handler when it is
+              const delayMs = (this.config.orderDelaySec ?? 0) * 1_000;
+              this.eligibleAfterTs.set(digest, Date.now() + delayMs);
+            }
+            break;
+          }
+
+          case "BrokerOrderCreatedEvent": {
+            const {
+              chainId,
+              symbol,
+              traderAddr,
+              digest,
+              type,
+            }: BrokerOrderMsg = JSON.parse(msg);
+            if (chainId !== this.chainId) {
+              break;
+            }
+            this.brokerHandled.add(digest);
+            this.addOrder(symbol, traderAddr, digest, type, undefined);
+            const delayMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
+            this.eligibleAfterTs.set(digest, Date.now() + delayMs);
+            this.scheduleBrokerExecution(symbol, digest);
             break;
           }
 
@@ -496,6 +531,8 @@ export default class Distributor {
       return;
     }
     this.openOrders.get(symbol)?.delete(digest);
+    this.brokerHandled.delete(digest);
+    this.eligibleAfterTs.delete(digest);
     logger.debug({
       info: "order removed",
       reason: reason,
@@ -573,7 +610,7 @@ export default class Distributor {
       while (true) {
         const [orders, digests] = (await executeWithTimeout(
           ob.pollRange(start, chunkSize),
-          10_000
+          this.RPC_TIMEOUT_MS
         )) as [any[], string[], unknown];
         let found = 0;
         for (let j = 0; j < orders.length; j++) {
@@ -700,7 +737,7 @@ export default class Distributor {
         const addressChunkBin = addressChunks.slice(i, i + rpcProviders.length);
         const accountChunk = await executeWithTimeout(
           Promise.allSettled(promises2.slice(i, i + rpcProviders.length)),
-          10_000
+          this.RPC_TIMEOUT_MS
         );
         accountChunk.map((results, j) => {
           if (results.status === "fulfilled") {
@@ -764,53 +801,57 @@ export default class Distributor {
    */
   private async checkOrders(symbol: string) {
     this.requireReady();
-    const orders = this.openOrders.get(symbol)!;
-    if (orders.size == 0) {
-      return;
+    const orders = this.openOrders.get(symbol);
+    if (!orders || orders.size === 0) return;
+    for (const digest of [...orders.keys()]) {
+      await this.tryExecute(symbol, digest);
     }
+  }
 
-    const removeOrders: string[] = [];
-    for (const [digest, orderBundle] of orders) {
-      const command: ExecuteOrderCommand = {
-        symbol: orderBundle.symbol,
-        digest: orderBundle.digest,
-        trader: orderBundle.trader,
-        reduceOnly: orderBundle.order?.reduceOnly,
-      };
-      // check if it's not too soon to send order for execution again
-      if (
-        Date.now() - (this.messageSentAt.get(command.digest) ?? 0) <
-        this.config.executeIntervalSecondsMin * 500
-      ) {
-        continue;
-      }
-
-      await this.waitUntilDelayElapsed();
-      if (!this.openOrders.get(symbol)?.has(digest)) continue;
-
+  // Returns true if a send was attempted
+  private async tryExecute(symbol: string, digest: string): Promise<boolean> {
+    const orderBundle = this.openOrders.get(symbol)?.get(digest);
+    if (!orderBundle || orderBundle.order === undefined) return false;
+    if ((this.eligibleAfterTs.get(digest) ?? 0) > Date.now()) return false;
+    if (
+      Date.now() - (this.messageSentAt.get(digest) ?? 0) <
+      this.config.executeIntervalSecondsMin * 500
+    ) {
+      return false;
+    }
+    const isMarket = orderBundle.order?.type === ORDER_TYPE_MARKET;
+    if (!isMarket) {
       try {
         await this.refreshPrices(symbol);
       } catch {
         logger.warn("error fetching from price service");
-        continue;
-      }
-      const curPx = this.pxSubmission.get(symbol)!;
-      if (curPx.s2MktClosed || curPx.s3MktClosed) {
-        logger.debug(`${symbol} market is closed`);
-        continue;
-      }
-
-      if (this.isExecutableIfOnChain(orderBundle, curPx.s2)) {
-        await this.sendCommand(command);
+        return false;
       }
     }
-    return;
+    const curPx = this.pxSubmission.get(symbol);
+    if (!curPx || curPx.s2MktClosed || curPx.s3MktClosed) return false;
+    if (!this.isExecutableIfOnChain(orderBundle, curPx.s2)) return false;
+    const command: ExecuteOrderCommand = {
+      symbol: orderBundle.symbol,
+      digest: orderBundle.digest,
+      trader: orderBundle.trader,
+      reduceOnly: orderBundle.order?.reduceOnly,
+    };
+    await this.sendCommand(command);
+    return true;
   }
 
-  private async waitUntilDelayElapsed() {
-    const delay = this.config.orderDelaySec ?? 0;
-    if (delay <= 0) return;
-    await sleep(delay * 1_000);
+  // broker-ws path
+  // wait 1 + delay seconds, then try execute; retry up to 4x1s if
+  // sentinel hasn't fired yet
+  private async scheduleBrokerExecution(symbol: string, digest: string) {
+    const waitMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
+    await sleep(waitMs);
+    for (let i = 0; i < 4; i++) {
+      if (await this.tryExecute(symbol, digest)) return;
+      if (!this.openOrders.get(symbol)?.has(digest)) return;
+      await sleep(1_000);
+    }
   }
 
   private async sendCommand(msg: ExecuteOrderCommand) {

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -903,6 +903,11 @@ export default class Distributor {
       if (await this.tryExecute(symbol, digest)) return;
       await sleep(1_000);
     }
+    // that's delay + 1 + 4 
+    const bundle = this.openOrders.get(symbol)?.get(digest);
+    if (bundle && bundle.order === undefined) {
+      this.removeOrder(symbol, digest, "broker stub timed out");
+    }
   }
 
   private async sendCommand(msg: ExecuteOrderCommand) {

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -81,12 +81,14 @@ export default class Distributor {
   constructor(config: ExecutorConfig, private executor: Executor) {
     this.config = config;
     const sdkConfig = PerpetualDataHandler.readSDKConfig(config.sdkConfig);
+
     if (config.priceFeedConfigNetwork !== undefined) {
       sdkConfig.priceFeedConfigNetwork = config.priceFeedConfigNetwork;
     }
     if (config.configSource !== undefined) {
       sdkConfig.configSource = config.configSource;
     }
+
     this.chainId = sdkConfig.chainId;
     this.redisSubClient = constructRedis("commanderSubClient");
     this.md = new MarketData(sdkConfig);
@@ -95,7 +97,6 @@ export default class Distributor {
         timeoutSeconds: 25,
         logErrors: true,
         logRpcSwitches: true,
-        // Distributor uses free rpcs, make sure to switch on each call.
         switchRpcOnEachRequest: true,
         staticNetwork: true,
       }),

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -42,12 +42,13 @@ import Executor from "./executor.js";
 import { logger } from "../logger.js";
 
 export default class Distributor {
-  // objects
+
+  // SDK instance
   private md: MarketData;
   private redisSubClient: Redis;
   public providers: MultiUrlJsonRpcProvider[];
 
-  // state
+  // Dynamic state info
   private blockNumber = 0;
   private priceCurveUpdatedAtBlock: Map<string, number> = new Map(); // symbol => block number
   private lastRefreshTime: Map<string, number> = new Map();
@@ -58,22 +59,20 @@ export default class Distributor {
   private midPremium: Map<string, number> = new Map();
   private unitAccumulatedFunding: Map<string, number> = new Map();
   private tradePremium: Map<string, [number, number]> = new Map();
-  // order digest => sent for execution timestamp
   private messageSentAt: Map<string, number> = new Map();
   private pricesFetchedAt: Map<string, number> = new Map();
   private refreshRpcIdx = 0;
   public ready: boolean = false;
 
-  // static info
+  // Static info
   private config: ExecutorConfig;
   private symbols: string[] = [];
   private chainId: number;
 
   // Last time when refreshAllOpenOrders was called
   private lastRefreshOfAllOpenOrders: Date = new Date();
-
+  // RPC timeout for calls made in distributor. The calls are expected to be fast enoug
   private readonly RPC_TIMEOUT_MS = 10_000;
-
   // Digests whose broker WS handler has taken ownership of execution
   private brokerHandled: Set<string> = new Set();
   // Earliest wall clock ms at which a digest may be sent for execution

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -11,7 +11,6 @@ import {
   ORDER_TYPE_MARKET,
   ORDER_TYPE_STOP_LIMIT,
   ORDER_TYPE_STOP_MARKET,
-  OrderStatus,
   PerpetualDataHandler,
   SELL_SIDE,
   ZERO_ORDER_ID,
@@ -21,11 +20,10 @@ import type {
   IPerpetualOrder,
   PerpStorage,
 } from "@d8-x/d8x-node-sdk/contracts/IPerpetualManager";
-import { JsonRpcProvider, Overrides, ZeroAddress } from "ethers";
+import { JsonRpcProvider } from "ethers";
 import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import {
-  BrokerOrderMsg,
   ExecuteOrderCommand,
   ExecutionFailedMsg,
   ExecutorConfig,
@@ -54,7 +52,6 @@ export default class Distributor {
   private lastRefreshTime: Map<string, number> = new Map();
   private openPositions: Map<string, Map<string, Position>> = new Map(); // symbol => (trader => Position)
   public openOrders: Map<string, Map<string, OrderBundle>> = new Map(); // symbol => (digest => order bundle)
-  private brokerOrders: Map<string, Map<string, number>> = new Map(); // symbol => (digest => received ts)
   private pxSubmission: Map<string, IdxPriceInfo> = new Map(); // symbol => px submission
   private markPremium: Map<string, number> = new Map();
   private midPremium: Map<string, number> = new Map();
@@ -173,9 +170,6 @@ export default class Distributor {
         // "preallocate" trader set
         this.openPositions.set(symbol, new Map());
         this.openOrders.set(symbol, new Map());
-        this.brokerOrders.set(symbol, new Map());
-        // dummy values
-        this.lastRefreshTime.set(symbol, 0);
         this.symbols.push(symbol);
       } catch (e) {
         // symbol is ignored if cannot fetch data about it
@@ -192,7 +186,6 @@ export default class Distributor {
       "ExecutionFailedEvent",
       "PerpetualLimitOrderCreatedEvent",
       "PerpetualLimitOrderCancelledEvent",
-      "BrokerOrderCreatedEvent",
       "Restart",
       "switch-mode",
       "listener-error",
@@ -368,25 +361,6 @@ export default class Distributor {
             break;
           }
 
-          case "BrokerOrderCreatedEvent": {
-            const {
-              chainId,
-              symbol,
-              traderAddr,
-              digest,
-              type,
-            }: BrokerOrderMsg = JSON.parse(msg);
-            if (chainId !== this.chainId) {
-              break;
-            }
-            this.addOrder(symbol, traderAddr, digest, type, undefined);
-            this.brokerOrders.get(symbol)!.set(digest, Date.now());
-            setTimeout(() => {
-              this.upgradeBrokerStubFromChain(symbol, traderAddr, digest);
-            }, 2_000);
-            break;
-          }
-
           case "listener-error":
           case "switch-mode":
             // Whenever something wrong happens on sentinel, refresh orders if
@@ -478,55 +452,6 @@ export default class Distributor {
       }
     }
     this.tradePremium.set(symbol, prem);
-  }
-
-  private async upgradeBrokerStubFromChain(
-    symbol: string,
-    trader: string,
-    digest: string
-  ) {
-    const bundle = this.openOrders.get(symbol)?.get(digest);
-    if (!bundle || bundle.order !== undefined) {
-      return;
-    }
-    try {
-      const status = await this.md.getOrderStatus(symbol, digest);
-      if (status !== OrderStatus.OPEN) {
-        return;
-      }
-      const provider =
-        this.providers[Math.floor(Math.random() * this.providers.length)];
-      const ob = this.md.getOrderBookContract(symbol, provider);
-      const [scOrder, deps] = await Promise.all([
-        ob.orderOfDigest(digest),
-        ob.orderDependency(digest),
-      ]);
-      if (scOrder.traderAddr === ZeroAddress) {
-        return;
-      }
-      const order = this.md.smartContractOrderToOrder(
-        scOrder as unknown as IPerpetualOrder.OrderStruct
-      );
-      order.parentChildOrderIds = [deps[0], deps[1]];
-      if (this.openOrders.get(symbol)?.get(digest)?.order !== undefined) {
-        return;
-      }
-      this.addOrder(symbol, trader, digest, order.type as OrderType, order);
-      logger.debug({
-        info: "broker stub upgraded via chain fallback",
-        symbol,
-        digest,
-        time: new Date(Date.now()).toISOString(),
-      });
-      await this.checkOrders(symbol);
-    } catch (e) {
-      logger.warn({
-        info: "upgradeBrokerStubFromChain failed",
-        symbol,
-        digest,
-        error: (e as Error)?.message ?? e,
-      });
-    }
   }
 
   private addOrder(
@@ -638,23 +563,37 @@ export default class Distributor {
     const rpcUrls = this.config.rpcWatch;
     const rpcURL = rpcUrls[this.refreshRpcIdx % rpcUrls.length];
     this.refreshRpcIdx = (this.refreshRpcIdx + 1) % rpcUrls.length;
-    const overrides: Overrides & { rpcURL: string } = { rpcURL };
     try {
-      const [orders, digests, traders] = await executeWithTimeout(
-        this.md.getAllOpenOrders(symbol, overrides),
-        10_000
-      );
-      for (let i = 0; i < orders.length; i++) {
-        const digest = digests[i];
-        if (!digest || digest == ZERO_ORDER_ID) continue;
-        orderBundles.set(digest, {
-          symbol,
-          trader: traders[i],
-          digest,
-          isPredictionMarket: isPred,
-          order: orders[i],
-          type: orders[i].type as OrderType,
-        });
+      const provider = new JsonRpcProvider(rpcURL, this.md.network, {
+        staticNetwork: true,
+      });
+      const ob = this.md.getOrderBookContract(symbol, provider);
+      const chunkSize = 500;
+      let start = 0;
+      while (true) {
+        const [orders, digests] = (await executeWithTimeout(
+          ob.pollRange(start, chunkSize),
+          10_000
+        )) as [any[], string[], unknown];
+        let found = 0;
+        for (let j = 0; j < orders.length; j++) {
+          const digest = digests[j];
+          if (!digest || digest === ZERO_ORDER_ID) break;
+          const co = orders[j];
+          const order = this.md.smartContractOrderToOrder(co);
+          order.parentChildOrderIds = [co.parentChildDigest1, co.parentChildDigest2];
+          orderBundles.set(digest, {
+            symbol,
+            trader: co.traderAddr,
+            digest,
+            isPredictionMarket: isPred,
+            order,
+            type: order.type as OrderType,
+          });
+          found++;
+        }
+        if (found < chunkSize) break;
+        start += found;
       }
     } catch (e) {
       logger.warn(
@@ -864,33 +803,14 @@ export default class Distributor {
       if (this.isExecutableIfOnChain(orderBundle, curPx.s2)) {
         await this.sendCommand(command);
       }
-      if (
-        orderBundle.order == undefined &&
-        Date.now() - (this.brokerOrders.get(symbol)?.get(digest) ?? 0) > 60_000
-      ) {
-        removeOrders.push(orderBundle.digest);
-        this.removeOrder(
-          orderBundle.symbol,
-          orderBundle.digest,
-          "broker order expired"
-        );
-      }
-    }
-    // cleanup
-    for (const digest of removeOrders) {
-      this.openOrders.get(symbol)?.delete(digest);
-      this.brokerOrders.get(symbol)?.delete(digest);
     }
     return;
   }
 
-  private async waitUntilDelayElapsed(orderBundle: OrderBundle) {
+  private async waitUntilDelayElapsed(_orderBundle: OrderBundle) {
     const delay = this.config.orderDelaySec ?? 0;
     if (delay <= 0) return;
-    const ts = orderBundle.order?.submittedTimestamp;
-    if (ts === undefined) return;
-    const remainingMs = (ts + delay) * 1_000 - Date.now();
-    if (remainingMs > 0) await sleep(remainingMs);
+    await sleep(delay * 1_000);
   }
 
   private async sendCommand(msg: ExecuteOrderCommand) {

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -42,7 +42,6 @@ import Executor from "./executor.js";
 import { logger } from "../logger.js";
 
 export default class Distributor {
-
   // SDK instance
   private md: MarketData;
   private redisSubClient: Redis;
@@ -108,7 +107,6 @@ export default class Distributor {
    * If none of the RPCs work, it sleeps before crashing.
    */
   public async initialize() {
-    // Create a proxy instance to access the blockchain
     let success = false;
     let i = 0;
     this.providers = this.providers.sort(() => Math.random() - 0.5);
@@ -179,7 +177,7 @@ export default class Distributor {
         this.openPositions.set(symbol, new Map());
         this.openOrders.set(symbol, new Map());
         this.symbols.push(symbol);
-      } catch (e) {
+      } catch {
         // symbol is ignored if cannot fetch data about it
         logger.info(`Could not fetch data for symbol ${symbol}`);
       }
@@ -322,8 +320,8 @@ export default class Distributor {
             }
             if (!this.brokerHandled.has(digest)) {
               // the order is not yet handled by broker WS path
-              // in this path only wait for the delay and try execute, without retries, 
-              // because if sentinel has not fired yet, it means the order is not yet in the open orders map, 
+              // in this path only wait for the delay and try execute, without retries,
+              // because if sentinel has not fired yet, it means the order is not yet in the open orders map,
               // and will be picked up by the block handler when it is
               const delayMs = (this.config.orderDelaySec ?? 0) * 1_000;
               this.eligibleAfterTs.set(digest, Date.now() + delayMs);
@@ -458,7 +456,7 @@ export default class Distributor {
     if (
       this.priceCurveUpdatedAtBlock.has(symbol) &&
       this.priceCurveUpdatedAtBlock.get(symbol)! >=
-      this.blockNumber + blockLatency
+        this.blockNumber + blockLatency
     ) {
       // price curve already updated at most X blocks ago
       return;
@@ -586,7 +584,7 @@ export default class Distributor {
         time: new Date(Date.now()).toISOString(),
         nextRefresh: new Date(
           (this.lastRefreshTime.get(symbol) ?? 0) +
-          this.config.refreshOrdersIntervalSecondsMin * 1_000
+            this.config.refreshOrdersIntervalSecondsMin * 1_000
         ),
       });
       return;
@@ -618,7 +616,10 @@ export default class Distributor {
           if (!digest || digest === ZERO_ORDER_ID) break;
           const co = orders[j];
           const order = this.md.smartContractOrderToOrder(co);
-          order.parentChildOrderIds = [co.parentChildDigest1, co.parentChildDigest2];
+          order.parentChildOrderIds = [
+            co.parentChildDigest1,
+            co.parentChildDigest2,
+          ];
           orderBundles.set(digest, {
             symbol,
             trader: co.traderAddr,
@@ -634,7 +635,9 @@ export default class Distributor {
       }
     } catch (e) {
       logger.warn(
-        `${symbol} ${new Date(Date.now()).toISOString()}: error refreshing open orders`,
+        `${symbol} ${new Date(
+          Date.now()
+        ).toISOString()}: error refreshing open orders`,
         e
       );
     }
@@ -765,7 +768,7 @@ export default class Distributor {
             });
           }
         });
-      } catch (e) {
+      } catch {
         logger.warn("Error fetching account chunk (RPC?)");
       }
     }
@@ -958,7 +961,7 @@ export default class Distributor {
     tradePrice = order.isPredictionMarket
       ? indexPrice + this.tradePremium.get(order.symbol)![sideIdx] * scale
       : indexPrice *
-      (1 + this.tradePremium.get(order.symbol)![sideIdx] * scale);
+        (1 + this.tradePremium.get(order.symbol)![sideIdx] * scale);
 
     let execute = false;
 

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -358,8 +358,10 @@ export default class Distributor {
             this.brokerHandled.add(digest);
             this.orderSource.set(digest, "broker");
             this.addOrder(symbol, traderAddr, digest, type, undefined);
-            const delayMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
-            this.eligibleAfterTs.set(digest, Date.now() + delayMs);
+            if (!this.eligibleAfterTs.has(digest)) {
+              const delayMs = ((this.config.orderDelaySec ?? 0) + 1) * 1_000;
+              this.eligibleAfterTs.set(digest, Date.now() + delayMs);
+            }
             this.scheduleBrokerExecution(symbol, digest);
             break;
           }

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -1,5 +1,6 @@
 import {
   Order,
+  ORDER_TYPE_MARKET,
   OrderExecutorTool,
   PerpetualDataHandler,
   ZERO_ORDER_ID,
@@ -390,28 +391,11 @@ export default class Executor {
     digest: string,
     selectedExecutorTool: OrderExecutorTool
   ): Promise<Order | undefined> {
+    // getOrderById already fetches orderOfDigest + orderDependency in a single
+    // multicall and sets order.parentChildOrderIds
     const order = await selectedExecutorTool.getOrderById(symbol, digest);
-
-    // Do not query for dependencies if order is not found - saves 1 rpc call
     if (!order) {
       return undefined;
-    }
-
-    // We can't bundle retrieval of orderbook sc and order in one go from
-    // getOrderById, so therefore we do this twice here.
-    let ob = selectedExecutorTool.getOrderBookContract(symbol);
-    // Pick random free rpc from distributor (we don't want to use paid executor
-    // rpc for this here)
-    const randomDistributorRPC =
-      this.distributor!.providers[
-      Math.floor(Math.random() * this.distributor!.providers.length)
-      ];
-    ob.connect(randomDistributorRPC);
-    // Make sure dependencies are fetched after order is fetched to introduce a
-    // slight 1 network call delay (xlayer chain problem)
-    const deps = await ob.orderDependency(digest);
-    if (order && deps) {
-      order.parentChildOrderIds = [deps[0], deps[1]];
     }
 
     return order;
@@ -500,13 +484,10 @@ export default class Executor {
       });
     }
 
-    const onChainTS = (() => {
-      if (onChainOrder != undefined) {
-        return onChainOrder.submittedTimestamp;
-      }
-    })();
+    const isMarket = onChainOrder?.type === ORDER_TYPE_MARKET;
+    const onChainTS = onChainOrder?.submittedTimestamp;
 
-    if (!onChainTS) {
+    if (!onChainOrder) {
       logger.debug({
         reason: "order not found",
         symbol: symbol,
@@ -579,7 +560,7 @@ export default class Executor {
     }
 
     const oracleTS = Math.min(...px.submission.timestamps);
-    if (oracleTS < onChainTS) {
+    if (!isMarket && onChainTS && oracleTS < onChainTS) {
       // let oracle cache expire before trying
       logger.debug({
         reason: "outdated off-chain oracle(s)",

--- a/src/sentinel/brokerListener.ts
+++ b/src/sentinel/brokerListener.ts
@@ -171,9 +171,15 @@ export default class BackendListener {
             chainId: this.chainId,
             symbol: this.md!.getSymbolFromPerpId(+perpId)!,
             perpetualId: +perpId,
-            traderAddr: traderAddr,
+            traderAddr,
             digest: `0x${orderId}`,
             type: flagToOrderType(BigInt(flags), BigInt(fLimitPrice)),
+            fAmount,
+            fLimitPrice,
+            fTriggerPrice,
+            iDeadline,
+            flags,
+            executionTimestamp,
           };
           logger.debug({
             event: "BrokerOrderCreated",

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,12 @@ export interface BrokerOrderMsg {
   traderAddr: string;
   digest: string;
   type: OrderType;
+  fAmount: string;
+  fLimitPrice: string;
+  fTriggerPrice: string;
+  iDeadline: number;
+  flags: number;
+  executionTimestamp: number;
 }
 
 export interface LiquidateMsg extends RedisMsg {


### PR DESCRIPTION
  - Adds orderDelaySec delay before execution, gated by a shared eligibleAfterTs map beween the broker ws and the sentinel ws. The first writer wins the execution
  - Broker WS gets its own retry/cleanup loop (replaces old chain fallback + 60 s expiry)
  - New tryExecute centralizes the per digest execute decision
  - Market orders now skip oracle staleness + price refresh
  - refreshAllOpenOrders rewritten as a chunked pollRange loop
  - getOrderByIdWithDependencies is collapsed to one SDK multicall
  - Fixes after AI review: 1/ broker did overwrite sentinel's delay time in case it got the order later (added an if check) - 2/ stale stubs cleaned up after retries
  
  This was merged into this branch before the 2 fixed of AI reviews : https://github.com/D8-X/d8x-order-executor/pull/50