### PR TITLE
fix: handle perp slot rotation and EMERGENCY->NORMAL transitions end-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@d8-x/d8x-node-sdk": "0.1.75",
+    "@d8-x/d8x-node-sdk": "0.1.79",
     "@pythnetwork/pyth-sdk-solidity": "^2.2.1",
     "@slack/webhook": "^7.0.2",
     "dotenv": "^16.0.3",

--- a/src/executor/distributor.ts
+++ b/src/executor/distributor.ts
@@ -129,6 +129,9 @@ export default class Distributor {
   // Re-entry guard for refreshAllOpenOrders so concurrent fire-and-forget
   // callers don't fan out duplicate RPC bursts.
   private refreshAllInFlight = false;
+  // Per-symbol in-flight init promises so concurrent first-touch events for
+  // the same new symbol coalesce on a single init.
+  private symbolInitInFlight: Map<string, Promise<boolean>> = new Map();
 
   constructor(config: ExecutorConfig, private executor: Executor) {
     this.config = config;
@@ -207,43 +210,7 @@ export default class Distributor {
     logger.debug({ info: "tracked symbols", symbols });
 
     for (const symbol of symbols) {
-      try {
-        // price info
-        this.pxSubmission.set(
-          symbol,
-          await this.md.fetchPricesForPerpetual(symbol)
-        );
-        // mark premium, accumulated funding per BC unit
-        const perpState = await this.md
-          .getReadOnlyProxyInstance()
-          .getPerpetual(this.md.getPerpIdFromSymbol(symbol));
-        this.markPremium.set(
-          symbol,
-          ABK64x64ToFloat(perpState.currentMarkPremiumRate.fPrice)
-        );
-        // mid premium = mark premium only at initialization time, will be updated with events
-        this.midPremium.set(
-          symbol,
-          ABK64x64ToFloat(perpState.currentMarkPremiumRate.fPrice)
-        );
-
-        this.unitAccumulatedFunding.set(
-          symbol,
-          ABK64x64ToFloat(perpState.fUnitAccumulatedFunding)
-        );
-
-        this.tradePremium.set(symbol, [
-          this.midPremium.get(symbol)! + 5e-4,
-          this.midPremium.get(symbol)! - 5e-4,
-        ]);
-        // "preallocate" trader set
-        this.openPositions.set(symbol, new Map());
-        this.openOrders.set(symbol, new Map());
-        this.symbols.push(symbol);
-      } catch {
-        // symbol is ignored if cannot fetch data about it
-        logger.info(`Could not fetch data for symbol ${symbol}`);
-      }
+      await this.ensureSymbolTracked(symbol);
     }
 
     // Subscribe to blockchain events
@@ -278,6 +245,87 @@ export default class Distributor {
     if (!this.ready) {
       throw new Error("not ready: await distributor.initialize()");
     }
+  }
+
+  /**
+   * Ensure all per-symbol state maps are populated for `symbol`. Used both at
+   * startup and lazily when an event arrives for a perp slot we don't track
+   * yet (e.g. a slot rotated to a new game, or a perp transitioned from
+   * EMERGENCY/INITIALIZING back to NORMAL during executor uptime).
+   *
+   * Concurrent calls for the same symbol coalesce on a single in-flight init.
+   * If the symbol is unknown to MarketData, the SDK is force-refreshed once;
+   * if still unknown the symbol is presumed bogus and we no-op. All RPC calls
+   * happen up front so a failure can't leave partial state in the maps.
+   */
+  private async ensureSymbolTracked(symbol: string): Promise<boolean> {
+    if (this.symbols.includes(symbol)) return true;
+    const inFlight = this.symbolInitInFlight.get(symbol);
+    if (inFlight) return inFlight;
+
+    const p = (async () => {
+      try {
+        let perpId: number;
+        try {
+          perpId = this.md.getPerpIdFromSymbol(symbol);
+        } catch {
+          // SDK's MD doesn't know this symbol yet — refresh and retry.
+          // SDK has internal mutex (refreshPromise) so concurrent
+          // refreshes coalesce.
+          await this.md.refreshSymbols(true);
+          try {
+            perpId = this.md.getPerpIdFromSymbol(symbol);
+          } catch (e) {
+            logger.warn({
+              info: "symbol unknown after MD refresh",
+              symbol,
+              err: (e as Error)?.message ?? String(e),
+            });
+            return false;
+          }
+        }
+        // RPC up front so a failure can't leave partial state.
+        const px = await this.md.fetchPricesForPerpetual(symbol);
+        const perpState = await this.md
+          .getReadOnlyProxyInstance()
+          .getPerpetual(perpId);
+        const markPrem = ABK64x64ToFloat(
+          perpState.currentMarkPremiumRate.fPrice
+        );
+
+        // Synchronous block: maps populated atomically from the runtime's
+        // view. `this.symbols.push` is the last write — `includes(symbol)`
+        // is the canonical "fully tracked" marker.
+        this.pxSubmission.set(symbol, px);
+        this.markPremium.set(symbol, markPrem);
+        this.midPremium.set(symbol, markPrem);
+        this.unitAccumulatedFunding.set(
+          symbol,
+          ABK64x64ToFloat(perpState.fUnitAccumulatedFunding)
+        );
+        this.tradePremium.set(symbol, [markPrem + 5e-4, markPrem - 5e-4]);
+        if (!this.openPositions.has(symbol)) {
+          this.openPositions.set(symbol, new Map());
+        }
+        if (!this.openOrders.has(symbol)) {
+          this.openOrders.set(symbol, new Map());
+        }
+        this.symbols.push(symbol);
+        return true;
+      } catch (e) {
+        logger.warn({
+          info: "symbol init failed",
+          symbol,
+          err: (e as Error)?.message ?? String(e),
+        });
+        return false;
+      } finally {
+        this.symbolInitInFlight.delete(symbol);
+      }
+    })();
+
+    this.symbolInitInFlight.set(symbol, p);
+    return p;
   }
 
   /**
@@ -364,6 +412,10 @@ export default class Distributor {
             if (chainId !== this.chainId) {
               break;
             }
+            // Lazily init the symbol if this is the first event we've seen
+            // for it (e.g. perp slot rotated mid-uptime). If init fails the
+            // markPremium write below would be orphaned, so bail.
+            if (!(await this.ensureSymbolTracked(symbol))) break;
             this.markPremium.set(symbol, markPremium);
             this.midPremium.set(symbol, midPremium);
             break;
@@ -380,6 +432,10 @@ export default class Distributor {
             if (chainId !== this.chainId) {
               break;
             }
+            // Lazy init must run before addOrder so we never leave a
+            // openOrders[symbol] entry with the symbol absent from
+            // this.symbols (would never be checked or refreshed).
+            if (!(await this.ensureSymbolTracked(symbol))) break;
             // Hold off execution until orderDelaySec has elapsed since the
             // order was first observed, so we don't submit before the on-chain
             // delay-required window has passed. The gate must be set before
@@ -413,6 +469,8 @@ export default class Distributor {
             if (m.chainId !== this.chainId) {
               break;
             }
+            // Lazy init before addOrder, same rationale as the sentinel path.
+            if (!(await this.ensureSymbolTracked(m.symbol))) break;
             this.brokerHandled.add(m.digest);
             this.orderSource.set(m.digest, "broker");
             this.addOrder(m.symbol, m.traderAddr, m.digest, m.type, this.brokerMsgToOrder(m));
@@ -556,13 +614,14 @@ export default class Distributor {
     }
     this.priceCurveUpdatedAtBlock.set(symbol, this.blockNumber);
     const prem = this.tradePremium.get(symbol)!;
+    const pxS2S3 = this.pxSubmission.get(symbol);
+    if (!pxS2S3 || pxS2S3.s2MktClosed || pxS2S3.s3MktClosed) {
+      // not initialized for this symbol (e.g. event arrived for a perp slot
+      // we don't track), or mkt is closed
+      return;
+    }
     for (const i of [0, 1]) {
       const side = [BUY_SIDE, SELL_SIDE][i];
-      const pxS2S3 = this.pxSubmission.get(symbol)!;
-      if (pxS2S3.s2MktClosed || pxS2S3.s3MktClosed) {
-        // mkt is closed
-        return;
-      }
       const tradeSize = this.getOrderAverage(symbol, side);
       if (tradeSize) {
         // empirical

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -72,6 +72,12 @@ export default class BlockhainListener {
 
   private orderBooks: Set<string> = new Set();
 
+  // Periodic refresh of MarketData's perpetualId -> symbol map. Without this,
+  // the cache built at startup goes stale when prediction-market perp slots
+  // are reused for new games, and we keep publishing events with old symbols.
+  private symbolCacheRefreshTimer?: NodeJS.Timeout;
+  private readonly SYMBOL_CACHE_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
   constructor(config: ExecutorConfig) {
     if (config.rpcListenHttp.length <= 0) {
       throw new Error(
@@ -272,25 +278,34 @@ export default class BlockhainListener {
 
     await this.md.createProxyInstance(this.httpProvider);
 
-    const perps = await this.md
+    // Load orderbook addresses for ALL deployed perps (regardless of state),
+    // so we don't have to maintain this set as perps transition between
+    // NORMAL / EMERGENCY / MARKET_CLOSED / etc. The address is stable per
+    // slot, so once added it stays correct even when the slot rotates to a
+    // new game. Perps with no orderbook deployed yet (empty
+    // limitOrderBookAddr — typically fresh INVALID slots) throw and are
+    // skipped silently.
+    const allPerpSymbols = await this.md
       .exchangeInfo()
       .then(({ pools }) =>
         pools
           .map(({ perpetuals, poolSymbol }) =>
-            perpetuals
-              .filter(({ state }) => state === "NORMAL")
-              .map(
-                ({ baseCurrency, quoteCurrency }) =>
-                  `${baseCurrency}-${quoteCurrency}-${poolSymbol}`
-              )
+            perpetuals.map(
+              ({ baseCurrency, quoteCurrency }) =>
+                `${baseCurrency}-${quoteCurrency}-${poolSymbol}`
+            )
           )
           .flat()
       );
 
-    for (const symbol of perps) {
-      this.orderBooks.add(
-        this.md.getOrderBookContract(symbol).target.toString()
-      );
+    for (const symbol of allPerpSymbols) {
+      try {
+        this.orderBooks.add(
+          this.md.getOrderBookContract(symbol).target.toString()
+        );
+      } catch {
+        // No orderbook deployed for this slot yet — skip.
+      }
     }
 
     if (this.config.rpcListenWs.length > 0) {
@@ -318,6 +333,25 @@ export default class BlockhainListener {
     this.connectWsOrSwitchToHttp();
     this.addListeners();
     this.resetHealthChecks();
+
+    this.symbolCacheRefreshTimer = setInterval(
+      () => void this.refreshSymbolMap("periodic"),
+      this.SYMBOL_CACHE_REFRESH_INTERVAL_MS
+    );
+  }
+
+  // SDK has internal mutex (refreshPromise) so concurrent calls coalesce.
+  private async refreshSymbolMap(reason: string): Promise<void> {
+    try {
+      await this.md.refreshSymbols(true);
+      logger.info({ info: "symbol cache refreshed", reason });
+    } catch (e) {
+      logger.warn({
+        info: "symbol cache refresh failed",
+        reason,
+        err: (e as Error)?.message ?? String(e),
+      });
+    }
   }
 
   private async addListeners() {
@@ -414,6 +448,12 @@ export default class BlockhainListener {
           args: parsedEvent.args,
           time: new Date(Date.now()).toISOString(),
         });
+        // SetNormalState fires when a perp slot becomes active with a
+        // (possibly new) symbol — e.g., a sports prediction slot rotates
+        // to the next game. Refresh so subsequent events resolve correctly.
+        if (parsedEvent.name === "SetNormalState") {
+          void this.refreshSymbolMap("SetNormalState");
+        }
         return;
 
       case "TransferAddressTo":

--- a/src/sentinel/brokerListener.ts
+++ b/src/sentinel/brokerListener.ts
@@ -33,6 +33,12 @@ export default class BackendListener {
   private chainId: number;
   private lastRpcIndex = { http: -1, ws: -1 };
 
+  // Periodic refresh of MarketData's perpetualId -> symbol map. BrokerListener
+  // has its own MarketData instance, so it needs its own refresh path —
+  // symmetric to the one in BlockchainListener.
+  private symbolCacheRefreshTimer?: NodeJS.Timeout;
+  private readonly SYMBOL_CACHE_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
   constructor(config: ExecutorConfig, wsIndex: number) {
     this.config = config;
     this.wsIndex = wsIndex;
@@ -62,6 +68,19 @@ export default class BackendListener {
     );
   }
 
+  private async refreshSymbolMap(reason: string): Promise<void> {
+    try {
+      await this.md.refreshSymbols(true);
+      logger.info({ info: "broker symbol cache refreshed", reason });
+    } catch (e) {
+      logger.warn({
+        info: "broker symbol cache refresh failed",
+        reason,
+        err: (e as Error)?.message ?? String(e),
+      });
+    }
+  }
+
   public async start() {
     // infer chain from provider
     const network = await executeWithTimeout(
@@ -82,19 +101,28 @@ export default class BackendListener {
       ).toISOString()}: http connection established with proxy @ ${this.md.getProxyAddress()}`
     );
 
-    // get perpetuals and order books
+    // Subscribe to ALL deployed perpetuals (not just NORMAL). Subscriptions
+    // for non-NORMAL perps sit idle on the broker side until the perp
+    // transitions to NORMAL — no resubscribe needed when state changes.
+    // Avoids the gap where perps that were INVALID/EMERGENCY/MARKET_CLOSED at
+    // startup never got a broker WS subscription and only reached the
+    // executor via the slower chain path.
     const info = await this.md.exchangeInfo();
     this.perpIds = info.pools
       .filter(({ isRunning }) => isRunning)
-      .map((pool) =>
-        pool.perpetuals
-          .filter(({ state }) => state === "NORMAL")
-          .map(({ id }) => BigInt(id))
-      )
+      .map((pool) => pool.perpetuals.map(({ id }) => BigInt(id)))
       .flat();
 
     // subscribe
     this.addListeners();
+
+    // Refresh perpetualId -> symbol cache periodically so events for a
+    // rotated slot get labeled with the current symbol. SDK has internal
+    // mutex (refreshPromise) so concurrent refreshes coalesce.
+    this.symbolCacheRefreshTimer = setInterval(
+      () => void this.refreshSymbolMap("periodic"),
+      this.SYMBOL_CACHE_REFRESH_INTERVAL_MS
+    );
 
     // reconnect
     setInterval(() => {
@@ -167,9 +195,21 @@ export default class BackendListener {
             executionTimestamp,
             orderId,
           } = msg.data as BrokerWSUpdateData;
+          const symbol = this.md.getSymbolFromPerpId(+perpId);
+          if (!symbol) {
+            // MD doesn't know this perpId yet (e.g. brand-new slot deployed
+            // after our last refresh). Drop the event rather than publish
+            // {symbol: undefined}; the periodic refresh will pick it up.
+            logger.warn({
+              info: "broker WS update for unknown perpId",
+              perpId,
+              topic: msg.topic,
+            });
+            break;
+          }
           const eventMsg: BrokerOrderMsg = {
             chainId: this.chainId,
-            symbol: this.md!.getSymbolFromPerpId(+perpId)!,
+            symbol,
             perpetualId: +perpId,
             traderAddr,
             digest: `0x${orderId}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8-x/d8x-node-sdk@0.1.75":
-  version "0.1.75"
-  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.75/331efc6ab69ad1514f9ae334cdaaa929c6600bc0#331efc6ab69ad1514f9ae334cdaaa929c6600bc0"
-  integrity sha512-hAo/qRmEi7Jd5mPmEjeh8U07shNXbDPSDybqM7Olopw7gTAoeTIjdvxdSggGj6tId8itcGNGb5o0G/Nmb6XEug==
+"@d8-x/d8x-node-sdk@0.1.79":
+  version "0.1.79"
+  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.79/df0f03986e9916e681e8d1ac6f6c34ed3f504abc#df0f03986e9916e681e8d1ac6f6c34ed3f504abc"
+  integrity sha512-BoXqJNcGYdDJWDtf+galcE0XchwLy5cmRzxnPsWyiD4608F6rm6H94lzm2URaIlP46Ritp+1OXCaP8uAZHw8EQ==
   dependencies:
     "@d8-x/d8x-price-wasm" "^1.0.33"
     "@typechain/ethers-v6" "^0.5.1"


### PR DESCRIPTION
…to-end

Four changes to stop the executor from silently dropping orders for perp slots whose state changed during service uptime.

1. Sentinel loads orderbook addresses for ALL deployed perps at startup (not just NORMAL). Slot state changes don't grow this set, so events from a perp transitioning EMERGENCY/MARKET_CLOSED/INITIALIZING -> NORMAL reach the handler instead of being filtered at bcl.ts:413.

2. Sentinel refreshes MarketData's perpetualId->symbol cache on every SetNormalState event and on a 15-min safety interval. Fixes the bug
   where prediction-market slot rotations (e.g. 100009: MLB_CIN_CHC ->
   MLB_WSH_MIA) caused sentinel to publish events with stale symbols that the executor then crashed on (s2MktClosed TypeError).

3. Executor gains ensureSymbolTracked(symbol) which lazily initializes pxSubmission/markPremium/etc. and pushes to this.symbols on first event for an untracked symbol. Force-refreshes its own MarketData on cache miss. Called before addOrder in PerpetualLimitOrderCreated / BrokerOrderCreated to avoid stranding orders in openOrders[symbol] without the symbol being in this.symbols (which checkOrders and refreshAllOpenOrders iterate). Also called from UpdateMarkPriceEvent to populate state proactively.

4. Ensure that broker ws listens not only to normal perpIDs but to all of them

Plus a defensive guard in updatePriceCurve mirroring the existing pattern at line 999, so any future unknown-symbol event no-ops instead of crashing.

Bumps @d8-x/d8x-node-sdk to 0.1.79 (refreshSymbols(true) is public from this version and rebuilds perpetualIdToSymbol via _fillSymbolMaps).